### PR TITLE
Fixes pairwise-distance.sh for read-only $indir

### DIFF
--- a/bin/pairwise-distance.sh
+++ b/bin/pairwise-distance.sh
@@ -10,22 +10,24 @@ while getopts ":d:i:" opt; do
   esac
 done
 
+outdir=${outdir:-$TMPDIR}
+
 cd ${indir};
 for i in *.sym; do
 printf "%s\t" $(basename ${i} .meth.sym);
 done
 echo;
 for i in *.sym; do
-  awk '{print $1 ":" $2 "\t" $5}' ${i} | sort -k 1b,1 > ${i}.tojoin;
+  awk '{print $1 ":" $2 "\t" $5}' ${i} | sort -k 1b,1 > $outdir/${i}.tojoin;
   printf "%s\t" $(basename ${i} .meth.sym);
   for j in *.sym; do
-    awk '{print $1 ":" $2 "\t" $5}' ${j} | sort -k 1b,1 > ${j}.tojoin;
-    join ${i}.tojoin ${j}.tojoin > temp;
-    x=$(awk 'BEGIN{distance=0}{distance+=($3-$2)^2;}END{print sqrt(distance)}' temp);
+    awk '{print $1 ":" $2 "\t" $5}' ${j} | sort -k 1b,1 > $outdir/${j}.tojoin;
+    join $outdir/${i}.tojoin $outdir/${j}.tojoin > $outdir/temp;
+    x=$(awk 'BEGIN{distance=0}{distance+=($3-$2)^2;}END{print sqrt(distance)}' $outdir/temp);
     printf "%s\t" ${x};
   done
   printf "\n";
 done;
 
-rm *.tojoin;
-rm temp;
+rm $outdir/*.tojoin;
+rm $outdir/temp;


### PR DESCRIPTION
Made outdir default to $TMPDIR if it is not not provided. The script is more robust this way, and we don't need to change pairwise-distance.cwl.

Tested by running pairwise-distance.cwl from inside a container and it works for me.

Fixes: Epigenomics-Screw/Screw#35